### PR TITLE
Add MAX_UID_SIZE

### DIFF
--- a/src/mod_auth_pubtkt.h
+++ b/src/mod_auth_pubtkt.h
@@ -47,6 +47,7 @@
 #define REMOTE_USER_TOKENS_ENV "REMOTE_USER_TOKENS"
 #define MIN_AUTH_COOKIE_SIZE 64	/* the Base64-encoded signature alone is >= 64 bytes */
 #define CACHE_SIZE 200			/* number of entries in ticket cache */
+#define MAX_UID_SIZE 32         /* maximum length of uid */
 #define MAX_TICKET_SIZE 1024	/* maximum length of raw ticket */
 
 #define PUBTKT_AUTH_VERSION "0.6"
@@ -76,7 +77,7 @@ typedef struct {
 
 /* Ticket structure */
 typedef struct {
-	char			uid[33];
+	char			uid[MAX_UID_SIZE+1];
 	char			clientip[40];
 	unsigned int	valid_until;
 	unsigned int	grace_period;


### PR DESCRIPTION
Fixed uid size of 32 is a bit short when using email addresses for that field, make that easier to change.
