### PR TITLE
Mark auth_pubtkt.conf as a config file 

### DIFF
--- a/mod_auth_pubtkt.spec
+++ b/mod_auth_pubtkt.spec
@@ -39,7 +39,7 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root,-)
 %{_libdir}/httpd/modules/*.so
-%{_sysconfdir}/httpd/conf.d/auth_pubtkt.conf
+%config %{_sysconfdir}/httpd/conf.d/auth_pubtkt.conf
 
 %changelog
 * Sat Sep 19 2009 Omachonu Ogali <oogali@currenex.com> 0.6-0


### PR DESCRIPTION
So it doesn't get overwritten on subsequent installs.
