### PR TITLE
Add TKTAuthBadIPURL

### DIFF
--- a/src/mod_auth_pubtkt.h
+++ b/src/mod_auth_pubtkt.h
@@ -63,6 +63,7 @@ typedef struct  {
 	char				*auth_cookie_name;
 	char				*back_arg_name;
 	char				*refresh_url;
+	char				*badip_url;
 	apr_array_header_t	*auth_token;
 	int					require_ssl;
 	int					debug;


### PR DESCRIPTION
Unique URL to redirect to if request IP doesn't match cookie IP.
Allows Login server to handle IP mismatch condition separately from
the default login URL behavior.
Defaults to TKTAuthLoginURL if not specified.
