### PR TITLE
Use useragent_ip instead of client_ip on Apache 2.4

### DIFF
--- a/src/mod_auth_pubtkt.c
+++ b/src/mod_auth_pubtkt.c
@@ -624,7 +624,7 @@ static int check_clientip(request_rec *r, auth_pubtkt *tkt) {
 		return 1;		/* no clientip in ticket */
 	
 #if AP_MODULE_MAGIC_AT_LEAST(20111130,0)
-	return (strcmp(tkt->clientip, r->connection->client_ip) == 0);
+	return (strcmp(tkt->clientip, r->useragent_ip) == 0);
 #else
 	return (strcmp(tkt->clientip, r->connection->remote_ip) == 0);
 #endif
@@ -837,7 +837,7 @@ static int auth_pubtkt_check(request_rec *r) {
 			"TKT: client IP mismatch (ticket: %s, request: %s) - redirecting to badip URL",
 			parsed->clientip,
 #if AP_MODULE_MAGIC_AT_LEAST(20111130,0)
-			r->connection->client_ip
+			r->useragent_ip
 #else
 			r->connection->remote_ip
 #endif


### PR DESCRIPTION
Although <tt>r->connection->client_ip</tt> is the 2.4 equivalent of <tt>r->connection->remote_ip</tt> in Apache 2.2, for mod_auth_pubtkt's use case it's more appropriate to check against <tt>r->useragent_ip</tt>, which is the IP of the actual user if there is a transparent load balancer or proxy between the user and the server.

For more details: https://httpd.apache.org/docs/2.4/developer/new_api_2_4.html
