### PR TITLE
TKTAuthHeader directive

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v0.9 (09/07/2015)
+-----------------
+- New option TKTAuthHeader allowing custom header(s) to be used instead
+  of a just a Cookie.
+
 v0.8 (06/28/2012)
 -----------------
 - new option TKTAuthPassthruBasicAuth and corresponding field in ticket

--- a/docs/install.html
+++ b/docs/install.html
@@ -301,8 +301,6 @@ sig=MC0CFDkCxODPml+cEvAuO+o5w7jcvv/UAhUAg/Z2vSIjpRhIDhvu7UXQLuQwSCF=
 
 <p>If you would like to use a custom header instead of a cookie (or want to use both), see the <code>TKTAuthHeader</code> directive.</p>
 
-<p>
-
 
 <h3>Generating tickets</h3>
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -148,6 +148,21 @@ AddModule mod_auth_pubtkt.c		# Apache 1.3 only
 			<li>If not set, <code>TKTAuthLoginURL</code> is used</li>
 		</ul>
 	</li>
+	<li><strong><code>TKTAuthHeader</code></strong>
+		<ul>
+            <li>A space separated list of headers to use for finding the ticket (case insensitive).
+                If this header specified is <code>Cookie</code> then the format of the
+                value expects to be a valid cookie (subject to the <code>TKTAuthCookieName</code> directive).
+
+                Any other header assumes the value is a simple URL-encoded value of the ticket.
+
+                The first header that has content is tried and any other tickets in other header(s) are ignored.
+
+                example, use Cookie first, fallback to X-My-Auth: <code>TKTAuthHeader Cookie X-My-Auth</code>
+                </li>
+			<li>Default: <code>Cookie</code></li>
+		</ul>
+	</li>
 	<li><strong><code>TKTAuthCookieName</code></strong>
 		<ul>
 			<li>Name of the authentication cookie to use</li>
@@ -283,6 +298,10 @@ sig=MC0CFDkCxODPml+cEvAuO+o5w7jcvv/UAhUAg/Z2vSIjpRhIDhvu7UXQLuQwSCF=
 </pre>
 
 <p>The ticket string is saved URL-encoded in a domain cookie, usually named <code>auth_pubtkt</code>, but this can be changed (using the <code>TKTAuthCookieName</code> directive).</p>
+
+<p>If you would like to use a custom header instead of a cookie (or want to use both), see the <code>TKTAuthHeader</code> directive.</p>
+
+<p>
 
 
 <h3>Generating tickets</h3>

--- a/mod_auth_pubtkt.conf
+++ b/mod_auth_pubtkt.conf
@@ -11,6 +11,11 @@ LoadModule auth_pubtkt_module   modules/mod_auth_pubtkt.so
 #    TKTAuthTimeoutURL http://sso.company.com/sso/login?timeout=1
 #    TKTAuthUnauthURL http://sso.company.com/sso/login?unauth=1
 #
+#    # This defaults to "Cookie" if not specified.  You may specify any number
+#    # of headers to try and they will be attempted in order.
+#    #
+#    TKTAuthHeader Cookie X-Then-Your-Custom
+#
 #    TKTAuthCookieName "auth_pubtkt"
 #    TKTAuthRequireSSL off
 #

--- a/src/mod_auth_pubtkt.h
+++ b/src/mod_auth_pubtkt.h
@@ -40,6 +40,7 @@
 #endif
 
 #define MOD_AUTH_PUBTKT_AUTH_TYPE "mod_auth_pubtkt"
+#define MOD_AUTH_PUBTKT_HEADER_NAME "Cookie"
 #define AUTH_COOKIE_NAME "auth_pubtkt"
 #define BACK_ARG_NAME "back"
 #define REMOTE_USER_ENV "REMOTE_USER"
@@ -52,7 +53,7 @@
 #define PASSTHRU_AUTH_KEY_SIZE 16	/* length of symmetric key for passthru basic auth encryption */
 #define PASSTHRU_AUTH_IV_SIZE 16
 
-#define PUBTKT_AUTH_VERSION "0.8"
+#define PUBTKT_AUTH_VERSION "0.9"
 
 /* ----------------------------------------------------------------------- */
 /* Per-directory configuration */
@@ -62,6 +63,7 @@ typedef struct  {
 	char				*timeout_url;
 	char				*post_timeout_url;
 	char				*unauth_url;
+	char				*auth_header_name;
 	char				*auth_cookie_name;
 	char				*back_arg_name;
 	char				*refresh_url;


### PR DESCRIPTION
At first I implemented this as a single override, making it mutually exclusive.  Instead, this implementation lets the user specify a list of headers to try in order.

By default, only "Cookie" is assumed if nothing is provided.

One use case of this, is to overcome buggy CORS header support in different browsers when working with an API that is protected by mod_auth_pubtkt, hosted on a different top level domain that the calling web application.  Allowing a custom header to be used instead of a cookie allows the API designer to provide a good cross-domain experience across all browsers.
