### PR TITLE
Build updates

### DIFF
--- a/configure
+++ b/configure
@@ -22,7 +22,7 @@ if [ $DIR = '.' ]; then
 fi
 
 usage() {
-  echo "usage: $ME [--apxs=/path/to/apxs] [--apachever=<1.3|2|2.2>] [--debug]"
+  echo "usage: $ME [--apxs=/path/to/apxs] [--apachever=<1.3|2|2.2|2.4>] [--debug]"
 }
 die() {
   echo $*
@@ -72,7 +72,7 @@ test -x $APXS || die "Error: missing apxs '$APXS' (use --apxs=/path/to/apxs)"
 # Get Apache version
 if [ -z "$VERSION" ]; then
 	HTTPD=`$APXS -q SBINDIR`/`$APXS -q TARGET`
-	test -x $HTTPD || die "Error: cannot determine apache version (use --apachever=<1.3|2|2.2>)"
+	test -x $HTTPD || die "Error: cannot determine apache version (use --apachever=<1.3|2|2.2|2.4>)"
 	VERSION=`$HTTPD -v | head -1 | sed -e 's/.*Apache\///' -e 's/^\([0-9]\.[0-9]*\).*/\1/'`
 fi
 # Standardise

--- a/configure
+++ b/configure
@@ -6,6 +6,14 @@
 # Defaults
 APXS=/usr/sbin/apxs
 test -x $APXS || unset APXS
+if [ -z $APXS ]; then
+  APXS=/usr/bin/apxs
+  test -x $APXS || unset APXS
+fi
+if [ -z $APXS ]; then
+  APXS=/usr/bin/apxs2
+  test -x $APXS || unset APXS
+fi
 
 ME=`basename $0`
 DIR=`dirname $0`

--- a/mod_auth_pubtkt.spec
+++ b/mod_auth_pubtkt.spec
@@ -19,8 +19,8 @@ Single sign-on module for Apache, based on mod_auth_tkt.
 %setup -q
 
 %build
-./configure --apxs=%{_sbindir}/apxs
-%{_sbindir}/apxs -c -Wc,"-Wall -ansi" -Wl,-lcrypto src/mod_auth_pubtkt.c
+./configure
+make
 
 %install
 rm -rf %{buildroot}


### PR DESCRIPTION
These changes fix some problems I ran into using the <tt>.spec</tt> file to build an RPM on CentOS 7 (which uses Apache 2.4).

The most important change is not duplicating the build steps in the <tt>.spec</tt> file that were already in the <tt>Makefile</tt>. The contents of <tt>Makedefs</tt> was being ignored when building an RPM.