### PR TITLE
Added TKTAuthDigest directive, updated docs & exmples.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v0.10 (2016-12-16)
+------------------
+- New option TKTAuthDigest allowing selection of the digest algorithm.
+  If not configured, the old defaults of SHA1 (for RSA privkey) and DSS1
+  (for DSA privkey) will be used.  SHA224, SHA256, SHA384, and SHA512 are
+  the additional valid algorithm values.  (Contributed by Jake Buchholz)
+
 v0.9 (09/07/2015)
 -----------------
 - New option TKTAuthHeader allowing custom header(s) to be used instead

--- a/docs/install.html
+++ b/docs/install.html
@@ -104,6 +104,13 @@ AddModule mod_auth_pubtkt.c		# Apache 1.3 only
 			<li>This public key will be used to verify ticket signatures</li>
 		</ul>
 	</li>
+	<li><strong><code>TKTAuthDigest</code></strong>
+		<ul>
+			<li>String indicating what digest algorithm to use when verifying ticket signatures</li>
+			<li>Valid values are SHA1, DSS1, SHA224, SHA256, SHA384, and SHA512</li>
+			<li>If not specified, the old defaults of SHA1 (for an RSA public key) or DSS1 (for a DSA public key) will be used.</li>
+		</ul>
+	</li>
 </ul>
 
 <h4>Directives for use in directory/location/.htaccess scope</h4>
@@ -283,7 +290,8 @@ AddModule mod_auth_pubtkt.c		# Apache 1.3 only
 	</li>
 	<li>sig (required)
 		<ul>
-			<li>a Base64 encoded RSA or DSA signature over the SHA-1 digest of the content of the ticket up to (but not including) the semicolon before 'sig'</li>
+			<li>a Base64 encoded RSA or DSA signature over the digest of the content of the ticket up to (but not including) the semicolon before 'sig'</li>
+			<li>The default digest is SHA-1, unless TKTAuthDigest has specified a different algorithm.</li>
 			<li>RSA: raw result; DSA: DER encoded sequence of two integers &ndash; see Dss-Sig-Value in RFC 2459</li>
 			<li><strong>must be the last item in the ticket string</strong></li>
 		</ul>
@@ -359,7 +367,7 @@ sig=MC0CFDkCxODPml+cEvAuO+o5w7jcvv/UAhUAg/Z2vSIjpRhIDhvu7UXQLuQwSCF=
   | openssl enc -base64 -A
 </pre>
 
-<p>Use <code>-dss1</code> for DSA, and <code>-sha1</code> for RSA.</p>
+<p>If TKTAuthDigest isn't being used, specify <code>-dss1</code> for DSA, and <code>-sha1</code> for RSA.  Otherwise specify the TKTAuthDigest directive's algorithm (i.e. <code>-sha256</code> for SHA256).</p>
 
 
 <h3>Verifying a ticket signature on the command line</h3>

--- a/mod_auth_pubtkt.spec
+++ b/mod_auth_pubtkt.spec
@@ -1,10 +1,10 @@
 Summary: Ticket-based authorization module for the Apache HTTP Server
 Name: mod_auth_pubtkt
-Version: 0.9
+Version: 0.10
 Release: 0
 License: Apache
 Group: Applications/System
-Source0: https://neon1.net/mod_auth_pubtkt/mod_auth_pubtkt-0.9.tar.gz
+Source0: https://neon1.net/mod_auth_pubtkt/mod_auth_pubtkt-0.10.tar.gz
 Source1: mod_auth_pubtkt.conf
 URL: https://neon1.net/mod_auth_pubtkt/
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
@@ -42,6 +42,9 @@ rm -rf %{buildroot}
 %config %{_sysconfdir}/httpd/conf.d/auth_pubtkt.conf
 
 %changelog
+* Fri Dec 16 2016 Jake Buchholz <jake@vib.org> 0.10-0
+- Updated to latest version of mod_auth_pubtkt [0.10]
+
 * Wed Sep 09 2015 Manuel Kasper <mk@neon1.net> 0.9-0
 - Updated to latest version of mod_auth_pubtkt [0.9]
 

--- a/perl-login/minimal_cgi/login.pl
+++ b/perl-login/minimal_cgi/login.pl
@@ -31,6 +31,7 @@ my $use_client_ip = 1 ; # should the ticket/cookie contain the client's IP addre
 ## TODO: DO NOT USE THESE keys in a production settings.
 ##       These are just for debugging/testing.
 my $key_type = "rsa";
+my $digest = undef; # defaults to sha1 or dss1, depending on $key_type
 my $public_key = "$FindBin::Bin/../key.pub.pem";
 my $private_key = "$FindBin::Bin/../key.priv.pem";
 
@@ -151,6 +152,7 @@ sub generate_pubtkt_cookie
 	my $ticket = pubtkt_generate(
 			privatekey => $private_key,
 			keytype    => $key_type,
+			digest     => $digest,
 			clientip   => ($use_client_ip) ? remote_addr() : undef,
 			userid     => $user_id,
 			validuntil => time() + $valid_until_delta,

--- a/perl-login/test_pubtkt.pl
+++ b/perl-login/test_pubtkt.pl
@@ -20,6 +20,7 @@ use mod_auth_pubtkt;
 my $ticket = pubtkt_generate(
 		privatekey => "key.priv.pem",
 		keytype    => "rsa",
+		digest     => undef,
 		clientip   => undef,
 		userid     => "102",
 		validuntil => time() + 86400,
@@ -34,6 +35,7 @@ print $ticket,"\n";
 my $ok = pubtkt_verify (
 		publickey => "key.pub.pem",
 		keytype   => "rsa",
+		digest    => undef,
 		ticket    => $ticket
 	);
 die "Ticket verification failed.\n" if not $ok;
@@ -46,6 +48,7 @@ $ticket =~ s/uid=102/uid=103/;
 $ok = pubtkt_verify (
 		publickey => "key.pub.pem",
 		keytype   => "rsa",
+		digest    => undef,
 		ticket    => $ticket
 	);
 

--- a/php-login/login.php
+++ b/php-login/login.php
@@ -20,6 +20,7 @@ $logfile = "private/login.log";
 $privkeyfile = "private/tkt_privkey_dsa.pem";
 $pubkeyfile = "private/tkt_pubkey_dsa.pem";
 $keytype = "DSA";
+$digest = "default";
 $localuserdb = "private/users.txt";
 $default_timeout = 86400;
 $default_graceperiod = 3600;
@@ -119,7 +120,7 @@ if ($_POST) {
 		$tkt_validuntil = time() + $res['timeout'];
 		
 		/* generate the ticket now and set a domain cookie */
-		$tkt = pubtkt_generate($privkeyfile, $keytype, $username,
+		$tkt = pubtkt_generate($privkeyfile, $keytype, $digest, $username,
 			$_SERVER['REMOTE_ADDR'], $tkt_validuntil, $res['graceperiod'], join(",", $res['tokens']), "");
 		setcookie("auth_pubtkt", $tkt, 0, "/", $domain, $secure_cookie);
 		
@@ -145,7 +146,7 @@ if ($_POST) {
 
 		/* Checking validity of the ticket and if we are between begin of grace 
 		   period and end of ticket validity. If so we can refresh ticket */
-		if (pubtkt_verify($pubkeyfile, $keytype, $ticket) && isset($tkt_graceperiod)
+		if (pubtkt_verify($pubkeyfile, $keytype, $digest, $ticket) && isset($tkt_graceperiod)
 		    && is_numeric($tkt_graceperiod) && ($tkt_graceperiod <= time()) 
 		    && (time() <= $tkt_validuntil)) {
 
@@ -157,7 +158,7 @@ if ($_POST) {
 				$tkt_validuntil = time() + $user_info['data']['timeout'];
 		
 				/* generate the ticket now and set a domain cookie */
-				$tkt = pubtkt_generate($privkeyfile, $keytype, $tkt_uid,
+				$tkt = pubtkt_generate($privkeyfile, $keytype, $digest, $tkt_uid,
 					$ticket['cip'], $tkt_validuntil, $user_info['data']['graceperiod'], join(",", $user_info['data']['tokens']), "");
 				setcookie("auth_pubtkt", $tkt, 0, "/", $domain, $secure_cookie);
 		

--- a/php-login/pubtkt.inc
+++ b/php-login/pubtkt.inc
@@ -19,6 +19,8 @@ define("OPENSSL_PATH", "/usr/bin/openssl");
 	Parameters:
 		privkeyfile		path to private key file (PEM format)
 		privkeytype		type of private key ("RSA" or "DSA")
+		digest			digest algorithm ("default" is sha1 or dss1)
+						also valid:  sha224, sha256, sha384, and sha512
 		uid				user ID/username
 		clientip		client IP address (optional; can be empty or null)
 		validuntil		expiration timestamp (e.g. time() + 86400)
@@ -30,7 +32,7 @@ define("OPENSSL_PATH", "/usr/bin/openssl");
 	Returns:
 		ticket string, or FALSE on failure
 */
-function pubtkt_generate($privkeyfile, $privkeytype, $uid, $clientip, $validuntil, $graceperiod, $tokens, $udata, $bauth = null) {
+function pubtkt_generate($privkeyfile, $privkeytype, $digest, $uid, $clientip, $validuntil, $graceperiod, $tokens, $udata, $bauth = null) {
 	
 	/* format ticket string */
 	$tkt = "uid=$uid;";
@@ -48,6 +50,9 @@ function pubtkt_generate($privkeyfile, $privkeytype, $uid, $clientip, $validunti
 		$algoparam = "-dss1";
 	else
 		$algoparam = "-sha1";
+
+	if ($digest != "default")
+		$algoparam = "-" . $digest;
 	
 	$fd = @proc_open(OPENSSL_PATH . " dgst $algoparam -binary -sign " . escapeshellarg($privkeyfile),
 		array(0 => array("pipe", "r"), 1 => array("pipe", "w")), $pipes);
@@ -118,12 +123,14 @@ function pubtkt_generate_php($privkey, $uid, $clientip, $validuntil, $graceperio
 	Parameters:
 		pubkeyfile		path to public key file (PEM format)
 		pubkeytype		type of public key ("RSA" or "DSA")
+		digest			digest algorithm ("default" is sha1 or dss1)
+						also valid:  sha224, sha256, sha384, and sha512
 		ticket			ticket string (including signature)
 	
 	Returns:
 		ticket valid true/false
 */
-function pubtkt_verify($pubkeyfile, $pubkeytype, $ticket) {
+function pubtkt_verify($pubkeyfile, $pubkeytype, $digest, $ticket) {
 	/* strip off signature */
 	$sigpos = strpos($ticket, ";sig=");
 	if ($sigpos === false)
@@ -145,6 +152,9 @@ function pubtkt_verify($pubkeyfile, $pubkeytype, $ticket) {
 		$algoparam = "-dss1";
 	else
 		$algoparam = "-sha1";
+
+	if ($digest != "default")
+		$algoparam = "-" . $digest;
 	
 	/* check DSA signature */
 	$fd = proc_open(OPENSSL_PATH . " dgst $algoparam -verify " . escapeshellarg($pubkeyfile) . 

--- a/src/mod_auth_pubtkt.h
+++ b/src/mod_auth_pubtkt.h
@@ -53,7 +53,7 @@
 #define PASSTHRU_AUTH_KEY_SIZE 16	/* length of symmetric key for passthru basic auth encryption */
 #define PASSTHRU_AUTH_IV_SIZE 16
 
-#define PUBTKT_AUTH_VERSION "0.9"
+#define PUBTKT_AUTH_VERSION "0.10"
 
 /* ----------------------------------------------------------------------- */
 /* Per-directory configuration */
@@ -75,6 +75,7 @@ typedef struct  {
 	int					grace_period;
 	int					passthru_basic_auth;
 	EVP_PKEY			*pubkey;	/* public key for signature verification */
+	const EVP_MD		*digest;	/* TKTAuthDigest */
 	const char			*passthru_basic_key;
 } auth_pubtkt_dir_conf;
 


### PR DESCRIPTION
Addresses concern in issue #19 and adds an optional `TKTAuthDigest` directive to select other more modern digests (SHA224, SHA256, SHA384, and SHA512).  If directive is not set, the old default SHA1/DSS1 is used.

Obviously, the same algorithm selected for `TKTAuthDigest` will need to also be used by whatever code is doing the authnz, signing the ticket, and sending it back to the mod_auth_pubtkt website.

Pull request includes version bump to v0.10.