### PR TITLE
Fix TKTAuthDigest algorithm selection.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+v0.11 (2017-02-28)
+- Fixes selection of digest algorithm when using TKTAuthDigest.
+
 v0.10 (2016-12-16)
 ------------------
 - New option TKTAuthDigest allowing selection of the digest algorithm.

--- a/src/mod_auth_pubtkt.c
+++ b/src/mod_auth_pubtkt.c
@@ -254,17 +254,17 @@ static const char *setup_pubkey(cmd_parms *cmd, void *cfg, const char *param) {
 static const char *setup_digest(cmd_parms *cmd, void *cfg, const char *param) {
 	auth_pubtkt_dir_conf *conf = (auth_pubtkt_dir_conf*)cfg;
 
-	if (strcasecmp(param, "SHA1")) {
+	if (strcasecmp(param, "SHA1") == 0) {
 		conf->digest = EVP_sha1();
-	} else if (strcasecmp(param, "DSS1")) {
+	} else if (strcasecmp(param, "DSS1") == 0) {
 		conf->digest = EVP_dss1();
-	} else if (strcasecmp(param, "SHA224")) {
+	} else if (strcasecmp(param, "SHA224") == 0) {
 		conf->digest = EVP_sha224();
-	} else if (strcasecmp(param, "SHA256")) {
+	} else if (strcasecmp(param, "SHA256") == 0) {
 		conf->digest = EVP_sha256();
-	} else if (strcasecmp(param, "SHA384")) {
+	} else if (strcasecmp(param, "SHA384") == 0) {
 		conf->digest = EVP_sha384();
-	} else if (strcasecmp(param, "SHA512")) {
+	} else if (strcasecmp(param, "SHA512") == 0) {
 		conf->digest = EVP_sha512();
 	} else {
 		return apr_pstrcat(cmd->pool, cmd->cmd->name, ": Invalid digest algorithm ", param, NULL);


### PR DESCRIPTION
This PR fixes selection of the digest algorithm when explicitly specifying TKTAuthDigest.

Version bump to 0.11 included.