### PR TITLE
Add Multifactor config options and logic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+v0.12 (2018-03-13)
+------------------
+- Add TKTAuthRequireMultifactor and TKTAuthMultifactorURL.
+  These can be used to protect certain Directory/Location directives 
+  with an additional login factor to achieve multifactor. Like the original
+  login, the multifactor method is left up to the ticket generation 
+  application, only requiring a attestation that multifactor has been 
+  supplied. (Contributed by Nick Ramser)
+
 v0.11 (2017-02-28)
 - Fixes selection of digest algorithm when using TKTAuthDigest.
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -218,6 +218,19 @@ AddModule mod_auth_pubtkt.c		# Apache 1.3 only
 			<li>length must be exactly 16 characters</li>
 		</ul>
 	</li>
+	<li><strong><code>TKTAuthRequireMultifactor</code> (since v0.12)</strong>
+		<ul>
+                        <li>If on, this directive will require the tickets "multifactor" field to be set to true.</li>
+                        <li>Allows a specific directive to require additional authentication that may not be required globally.</li>
+			<li>Default: off</li>
+		</ul>
+	</li>
+	<li><strong><code>TKTAuthMultifactorURL</code> (since v0.12)</strong>
+		<ul>
+			<li>URL that users whose ticket doesn't contain the required multifactor value will be redirected to</li>
+			<li>If not set, <code>TKTAuthLoginURL</code> is used</li>
+		</ul>
+	</li>
 	<li><strong><code>TKTAuthDebug</code></strong>
 		<ul>
 			<li>debug level (1-3, higher for more debug output)</li>
@@ -288,6 +301,12 @@ AddModule mod_auth_pubtkt.c		# Apache 1.3 only
 			</li>
 		</ul>
 	</li>
+	<li>multifactor (optional; since v0.12)
+		<ul>
+                    <li>A int value(0/1) that denotes the current status of multifactor for a user</li>
+                    <li>Defaults to 0 if this key is not present</li>
+		</ul>
+	</li>
 	<li>sig (required)
 		<ul>
 			<li>a Base64 encoded RSA or DSA signature over the digest of the content of the ticket up to (but not including) the semicolon before 'sig'</li>
@@ -301,7 +320,7 @@ AddModule mod_auth_pubtkt.c		# Apache 1.3 only
 <p>Here's an example of how a real (DSA) ticket looks:</p>
 
 <pre>
-uid=mkasper;cip=192.168.200.163;validuntil=1201383542;tokens=foo,bar;udata=mydata;
+uid=mkasper;cip=192.168.200.163;validuntil=1201383542;tokens=foo,bar;udata=mydata;multifactor=1;
 sig=MC0CFDkCxODPml+cEvAuO+o5w7jcvv/UAhUAg/Z2vSIjpRhIDhvu7UXQLuQwSCF=
 </pre>
 

--- a/mod_auth_pubtkt.spec
+++ b/mod_auth_pubtkt.spec
@@ -1,10 +1,10 @@
 Summary: Ticket-based authorization module for the Apache HTTP Server
 Name: mod_auth_pubtkt
-Version: 0.10
+Version: 0.12
 Release: 0
 License: Apache
 Group: Applications/System
-Source0: https://neon1.net/mod_auth_pubtkt/mod_auth_pubtkt-0.10.tar.gz
+Source0: https://neon1.net/mod_auth_pubtkt/mod_auth_pubtkt-0.12.tar.gz
 Source1: mod_auth_pubtkt.conf
 URL: https://neon1.net/mod_auth_pubtkt/
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
@@ -42,6 +42,9 @@ rm -rf %{buildroot}
 %config %{_sysconfdir}/httpd/conf.d/auth_pubtkt.conf
 
 %changelog
+* Tue Mar 13 2018 Nick Ramser <nick.ramser@gmail.com> 0.12-0
+- Updated to latest version of mod_auth_pubtkt [0.12]
+
 * Fri Dec 16 2016 Jake Buchholz <jake@vib.org> 0.10-0
 - Updated to latest version of mod_auth_pubtkt [0.10]
 

--- a/php-login/pubtkt.inc
+++ b/php-login/pubtkt.inc
@@ -28,11 +28,12 @@ define("OPENSSL_PATH", "/usr/bin/openssl");
 		udata			user data (optional)
 		bauth			basic auth username:password (for passthru, optional;
 						can optionally use pubtkt_encrypt_bauth() to encrypt it)
+		multifactor             boolean (optional). Notes if multifactor authentication is present
 	
 	Returns:
 		ticket string, or FALSE on failure
 */
-function pubtkt_generate($privkeyfile, $privkeytype, $digest, $uid, $clientip, $validuntil, $graceperiod, $tokens, $udata, $bauth = null) {
+function pubtkt_generate($privkeyfile, $privkeytype, $digest, $uid, $clientip, $validuntil, $graceperiod, $tokens, $udata, $bauth = null, $multifactor = false) {
 	
 	/* format ticket string */
 	$tkt = "uid=$uid;";
@@ -43,8 +44,14 @@ function pubtkt_generate($privkeyfile, $privkeytype, $digest, $uid, $clientip, $
 		$tkt .= "graceperiod=".($validuntil-$graceperiod).";";
 	}
 	if (!empty($bauth))
-		$tkt .= "bauth=" . base64_encode($bauth) . ";";
-	$tkt .= "tokens=$tokens;udata=$udata";
+		$tkt .= "bauth=" . base64_encode($bauth) . ";"
+
+        if ($multifactor) {
+                $multifactor_int = 1;
+        } else {
+                $multifactor_int = 0;
+        }
+        $tkt .= "tokens=$tokens;udata=$udata;multifactor=$multifactor_int";
 	
 	if ($privkeytype == "DSA")
 		$algoparam = "-dss1";

--- a/src/mod_auth_pubtkt.h
+++ b/src/mod_auth_pubtkt.h
@@ -77,6 +77,8 @@ typedef struct  {
 	EVP_PKEY			*pubkey;	/* public key for signature verification */
 	const EVP_MD		*digest;	/* TKTAuthDigest */
 	const char			*passthru_basic_key;
+        int                             require_multifactor;
+        char                            *multifactor_url;
 } auth_pubtkt_dir_conf;
 
 /* Ticket structure */
@@ -88,6 +90,7 @@ typedef struct {
 	char			bauth[256];
 	char			tokens[256];
 	char			user_data[256];
+        int                     multifactor;
 } auth_pubtkt;
 
 typedef struct {


### PR DESCRIPTION
### Summary
We have several websites which we are required to protect with multifactor authentication (MFA). mod_auth_pubtkt was only knows if the user has a valid ticket or not, and has no insight into the authentication method (by design). However, due to this, we were unable to use it on the two factor required sites without including the MFA info in our udata and requiring the applications to validate it themselves. I extended the project to include an explicit flag for MFA in the ticket as well as config options. By separating it out into another field in the ticket, users are only asked for MFA the first time is required, and not when logging in to every site. 

Please feel free to decline the pull request if this is not something you feel should be handled inside by the module.

### Details
Added two new apache configuration options:
- TKTAuthRequireMultifactor: This is used to tell a given Directory/Location/.htaccess directive if content need to be protected by a multifactor.
- TKTAuthMultifactorURL: This is used to tell the module where to redirect to if multifactor is required, but missing from the ticket. Defaults to the TKTAuthLoginURL

Added a new field to the ticket:

- mulitfactor: Should have a value of 0 or 1 based on the if the user has completed multifactor auth. Defaults to 0 if the ticket does not contain the field.

### Notes
This should be able to be used with just about any mulitfactor solution. We use it with TOTP, asking the user for a login token before proceeding to a protected site. I believe it could also be used with commercials solutions (Duo, Otka, etc..) by using their authentication APIs to validate users before writing the cookie, although this has not been tested.

Updates to the version number, change log, spec file, php sample code, and documentation have also been provided. Feel free to update any of those as you see fit. 

Thanks for the great module!
 