### PR TITLE
use X-Forwarded-Proto if X-Forwarded-Host is not available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_CONFIG_AUX_DIR([.])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 AC_CONFIG_SRCDIR([src/ap_compat.h])
-AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_HEADERS([src/config.h])
 
 # Checks for programs.
 AC_PROG_CC

--- a/src/mod_auth_pubtkt.h
+++ b/src/mod_auth_pubtkt.h
@@ -20,6 +20,7 @@
 #endif
 
 #include "httpd.h"
+#include "config.h"
 #include "http_config.h"
 #include "http_log.h"
 #include "http_core.h"


### PR DESCRIPTION
AWS ALB doesn't send X-Forwarded-Host, but it does send X-Forwarded-Port. This fixes an issue where it fell back
to the server port instead of the client port available in X-Forwarded-Port.

Fixed #32 as well.